### PR TITLE
fix: bug with conflicts

### DIFF
--- a/react-todomvc/src/automerge_hooks.ts
+++ b/react-todomvc/src/automerge_hooks.ts
@@ -24,7 +24,12 @@ function initDoc(): Doc<TodoApp>{
   let changeFn = (doc: TodoApp) => {
     doc.todos = []
   }
-  let doc = automerge.change<Doc<TodoApp>>(automerge.init('0000'), { time: 0 }, changeFn);
+  let change = automerge.getLastLocalChange(
+    automerge.change<Doc<TodoApp>>(automerge.init('0000'), { time: 0 }, changeFn)
+  );
+  let [doc, patch] = automerge.applyChanges<TodoApp>(
+    automerge.init(), [change]
+  )
   return doc
 }
 


### PR DESCRIPTION
This is actually broken on the latest automerge (my fault: https://github.com/alexjg/automerge-todomvc-http/pull/1) 

To reproduce:

0. Open two browsers
1. Add remote http://127.0.0.1:5000/groceries
2. Add some items to todo list on both sides
3. Hit 'push' on one side
4. Hit 'fetch' on the other
```
new.js:1536 Uncaught (in promise) RangeError: Expected seq 3, got seq 2 from actor 0000
    at applyChanges (new.js:1536)
    at BackendDoc.applyChanges (new.js:1778)
    at Object.applyChanges (backend.js:29)
    at Object.applyChanges (automerge.js:93)
    at AutomergeTodos.<anonymous> (automerge_hooks.ts:85)
    at Generator.next (<anonymous>)
    at tslib.es6.js:74
    at new Promise (<anonymous>)
    at __awaiter (tslib.es6.js:70)
    at AutomergeTodos.applyChanges (automerge_hooks.ts:82)
```

New changes should fix this. 

Also looking at making this part of the automerge library, this explains the issue: https://github.com/automerge/automerge/issues/374